### PR TITLE
Adding code for PUMS compression blog post

### DIFF
--- a/2023-03-07-scaling-down-pums-compression/pums_compression.ipynb
+++ b/2023-03-07-scaling-down-pums-compression/pums_compression.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "3909511e-06a3-4b2e-a9b0-94739518e5e6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pyarrow as pa\n",
+    "from pyarrow import parquet\n",
+    "import pyarrow.dataset as ds"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "2637096e-9103-4854-99c1-5e393faaa052",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open dataset\n",
+    "dataset = ds.dataset('.', format=\"csv\", exclude_invalid_files=True)#, schema=nuschem)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "d5430863-f59d-42f6-bc50-916559336004",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First line needed for person and housing data, second for person only. \n",
+    "nuschem = dataset.schema.set(1, pa.field(\"SERIALNO\", pa.string()))\n",
+    "nuschem = dataset.schema.set(75, pa.field(\"WKWN\", pa.string()))\n",
+    "#Read using the new schema.\n",
+    "dataset = ds.dataset('.', format=\"csv\", exclude_invalid_files=True, schema=nuschem)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79e4a9e1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Now, we write to Parquet\n",
+    "ds.write_dataset(dataset, \"naive_pums\", format=\"parquet\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.16"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This PR adds code for the blog post [Scaling Down: The Python Libraries You Need to Compress and Analyze the PUMS Dataset](https://voltrondata.com/resources/scaling-down-python-libraries-compress-analyze-pums-dataset)